### PR TITLE
Remove commonLabels for resolving immutable issue

### DIFF
--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: zcp-system
-commonLabels:
-  release: zcp-monitoring
+#commonLabels:
+#  release: zcp-monitoring
 bases:
 - ./alertmanager
 - ./grafana

--- a/templates/aks/kustomization.yaml
+++ b/templates/aks/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: zcp-system
-commonLabels:
-  release: zcp-monitoring
+#commonLabels:
+#  release: zcp-monitoring
 bases:
 - ../../providers/aks
 #patchesStrategicMerge:

--- a/templates/eks/kustomization.yaml
+++ b/templates/eks/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: zcp-system
-commonLabels:
-  release: zcp-monitoring
+#commonLabels:
+#  release: zcp-monitoring
 bases:
 - ../../providers/eks
 #patchesStrategicMerge:

--- a/templates/iks/kustomization.yaml
+++ b/templates/iks/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: zcp-system
-commonLabels:
-  release: zcp-monitoring
+#commonLabels:
+#  release: zcp-monitoring
 bases:
 - ../../providers/iks
 #patchesStrategicMerge:


### PR DESCRIPTION
Remove commonLabels for the following kustomize comment.
```
Note: commonLabels should only be set for immutable labels, since they will be applied to Selectors.
```
https://kubectl.docs.kubernetes.io/pages/app_management/labels_and_annotations.html

#40 issue will be rolled back.