### PR TITLE
Update exporters to the lastest stable version

### DIFF
--- a/base/exporters/blackbox-exporter/blackbox-exporter-deployment.yaml
+++ b/base/exporters/blackbox-exporter/blackbox-exporter-deployment.yaml
@@ -31,7 +31,7 @@ spec:
               - key: node-role.kubernetes.io/management
                 operator: Exists
       containers:
-        - image: registry.au-syd.bluemix.net/cloudzcp/blackbox-exporter:v0.12.0
+        - image: au.icr.io/cloudzcp/blackbox-exporter:v0.16.0
           resources:
             requests:
               cpu: 5m

--- a/base/exporters/kube-state-metric/kube-state-metrics-deployment.yaml
+++ b/base/exporters/kube-state-metric/kube-state-metrics-deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     component: kube-state-metrics 
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      component: kube-state-metrics
   template:
     metadata:
       name: kube-state-metrics
@@ -33,7 +36,36 @@ spec:
       serviceAccountName: zcp-system-admin
       containers:
         - name: kube-state-metrics
-          image: registry.au-syd.bluemix.net/cloudzcp/kube-state-metrics:v1.6.0
+          image: au.icr.io/cloudzcp/kube-state-metrics:v1.9.5
+          args:
+          - --collectors=certificatesigningrequests
+          - --collectors=configmaps
+          - --collectors=cronjobs
+          - --collectors=daemonsets
+          - --collectors=deployments
+          - --collectors=endpoints
+          - --collectors=horizontalpodautoscalers
+          - --collectors=ingresses
+          - --collectors=jobs
+          - --collectors=limitranges
+          - --collectors=mutatingwebhookconfigurations
+          - --collectors=namespaces
+          - --collectors=networkpolicies
+          - --collectors=nodes
+          - --collectors=persistentvolumeclaims
+          - --collectors=persistentvolumes
+          - --collectors=poddisruptionbudgets
+          - --collectors=pods
+          - --collectors=replicasets
+          - --collectors=replicationcontrollers
+          - --collectors=resourcequotas
+          - --collectors=secrets
+          - --collectors=services
+          - --collectors=statefulsets
+          - --collectors=storageclasses
+#          - --collectors=validatingwebhookconfigurations
+#          - --collectors=verticalpodautoscalers
+          - --collectors=volumeattachments
           resources:
             requests:
               cpu: 10m

--- a/base/exporters/node-exporter/node-exporter-ds-svc.yaml
+++ b/base/exporters/node-exporter/node-exporter-ds-svc.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/base/exporters/node-exporter/node-exporter-ds.yaml
+++ b/base/exporters/node-exporter/node-exporter-ds.yaml
@@ -4,6 +4,10 @@ metadata:
   name: node-exporter
   namespace: zcp-system
 spec:
+  selector:
+    matchLabels:
+      app: prometheus
+      component: node-exporter
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
@@ -18,7 +22,7 @@ spec:
       tolerations:
       - operator: Exists
       containers:
-      - image: registry.au-syd.bluemix.net/cloudzcp/node-exporter:v0.15.2
+      - image: au.icr.io/cloudzcp/node-exporter:v0.18.1
         name: node-exporter
         args:
           - --path.procfs=/host/proc

--- a/base/prometheus/kustomization.yaml
+++ b/base/prometheus/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
 - prometheus-ingress.yaml
 configMapGenerator:
 - files:
+  - rules/16-compatibility.rules
   - rules/alertmanager.rules
   - rules/component-up-monitoring.rules
   - rules/elasticsearch.rules

--- a/base/prometheus/rules/16-compatibility.rules
+++ b/base/prometheus/rules/16-compatibility.rules
@@ -1,0 +1,201 @@
+groups:
+- name: node_exporter-16-bcache
+  rules:
+  - expr: node_bcache_cache_read_races
+    record: node_bcache_cache_read_races_total
+- name: node_exporter-16-buddyinfo
+  rules:
+  - expr: node_buddyinfo_blocks
+    record: node_buddyinfo_count
+- name: node_exporter-16-stat
+  rules:
+  - expr: node_boot_time_seconds
+    record: node_boot_time
+  - expr: node_time_seconds
+    record: node_time
+  - expr: node_context_switches_total
+    record: node_context_switches
+  - expr: node_forks_total
+    record: node_forks
+  - expr: node_intr_total
+    record: node_intr
+- name: node_exporter-16-cpu
+  rules:
+  - expr: label_replace(node_cpu_seconds_total, "cpu", "$1", "cpu", "cpu(.+)")
+    record: node_cpu
+- name: node_exporter-16-diskstats
+  rules:
+  - expr: node_disk_read_bytes_total
+    record: node_disk_bytes_read
+  - expr: node_disk_written_bytes_total
+    record: node_disk_bytes_written
+  - expr: node_disk_io_time_seconds_total * 1000
+    record: node_disk_io_time_ms
+  - expr: node_disk_io_time_weighted_seconds_total
+    record: node_disk_io_time_weighted
+  - expr: node_disk_reads_completed_total
+    record: node_disk_reads_completed
+  - expr: node_disk_reads_merged_total
+    record: node_disk_reads_merged
+  - expr: node_disk_read_time_seconds_total * 1000
+    record: node_disk_read_time_ms
+  - expr: node_disk_writes_completed_total
+    record: node_disk_writes_completed
+  - expr: node_disk_writes_merged_total
+    record: node_disk_writes_merged
+  - expr: node_disk_write_time_seconds_total * 1000
+    record: node_disk_write_time_ms
+- name: node_exporter-16-filesystem
+  rules:
+  - expr: node_filesystem_free_bytes
+    record: node_filesystem_free
+  - expr: node_filesystem_avail_bytes
+    record: node_filesystem_avail
+  - expr: node_filesystem_size_bytes
+    record: node_filesystem_size
+- name: node_exporter-16-infiniband
+  rules:
+  - expr: node_infiniband_port_data_received_bytes_total
+    record: node_infiniband_port_data_received_bytes
+  - expr: node_infiniband_port_data_transmitted_bytes_total
+    record: node_infiniband_port_data_transmitted_bytes
+- name: node_exporter-16-interrupts
+  rules:
+  - expr: node_interrupts_total
+    record: node_interrupts
+- name: node_exporter-16-memory
+  rules:
+  - expr: node_memory_Active_bytes
+    record: node_memory_Active
+  - expr: node_memory_Active_anon_bytes
+    record: node_memory_Active_anon
+  - expr: node_memory_Active_file_bytes
+    record: node_memory_Active_file
+  - expr: node_memory_AnonHugePages_bytes
+    record: node_memory_AnonHugePages
+  - expr: node_memory_AnonPages_bytes
+    record: node_memory_AnonPages
+  - expr: node_memory_Bounce_bytes
+    record: node_memory_Bounce
+  - expr: node_memory_Buffers_bytes
+    record: node_memory_Buffers
+  - expr: node_memory_Cached_bytes
+    record: node_memory_Cached
+  - expr: node_memory_CommitLimit_bytes
+    record: node_memory_CommitLimit
+  - expr: node_memory_Committed_AS_bytes
+    record: node_memory_Committed_AS
+  - expr: node_memory_DirectMap2M_bytes
+    record: node_memory_DirectMap2M
+  - expr: node_memory_DirectMap4k_bytes
+    record: node_memory_DirectMap4k
+  - expr: node_memory_Dirty_bytes
+    record: node_memory_Dirty
+  - expr: node_memory_HardwareCorrupted_bytes
+    record: node_memory_HardwareCorrupted
+  - expr: node_memory_Hugepagesize_bytes
+    record: node_memory_Hugepagesize
+  - expr: node_memory_Inactive_bytes
+    record: node_memory_Inactive
+  - expr: node_memory_Inactive_anon_bytes
+    record: node_memory_Inactive_anon
+  - expr: node_memory_Inactive_file_bytes
+    record: node_memory_Inactive_file
+  - expr: node_memory_KernelStack_bytes
+    record: node_memory_KernelStack
+  - expr: node_memory_Mapped_bytes
+    record: node_memory_Mapped
+  - expr: node_memory_MemAvailable_bytes
+    record: node_memory_MemAvailable
+  - expr: node_memory_MemFree_bytes
+    record: node_memory_MemFree
+  - expr: node_memory_MemTotal_bytes
+    record: node_memory_MemTotal
+  - expr: node_memory_Mlocked_bytes
+    record: node_memory_Mlocked
+  - expr: node_memory_NFS_Unstable_bytes
+    record: node_memory_NFS_Unstable
+  - expr: node_memory_PageTables_bytes
+    record: node_memory_PageTables
+  - expr: node_memory_Shmem_bytes
+    record: node_memory_Shmem
+  - expr: node_memory_ShmemHugePages_bytes
+    record: node_memory_ShmemHugePages
+  - expr: node_memory_ShmemPmdMapped_bytes
+    record: node_memory_ShmemPmdMapped
+  - expr: node_memory_Slab_bytes
+    record: node_memory_Slab
+  - expr: node_memory_SReclaimable_bytes
+    record: node_memory_SReclaimable
+  - expr: node_memory_SUnreclaim_bytes
+    record: node_memory_SUnreclaim
+  - expr: node_memory_SwapCached_bytes
+    record: node_memory_SwapCached
+  - expr: node_memory_SwapFree_bytes
+    record: node_memory_SwapFree
+  - expr: node_memory_SwapTotal_bytes
+    record: node_memory_SwapTotal
+  - expr: node_memory_Unevictable_bytes
+    record: node_memory_Unevictable
+  - expr: node_memory_VmallocChunk_bytes
+    record: node_memory_VmallocChunk
+  - expr: node_memory_VmallocTotal_bytes
+    record: node_memory_VmallocTotal
+  - expr: node_memory_VmallocUsed_bytes
+    record: node_memory_VmallocUsed
+  - expr: node_memory_Writeback_bytes
+    record: node_memory_Writeback
+  - expr: node_memory_WritebackTmp_bytes
+    record: node_memory_WritebackTmp
+- name: node_exporter-16-network
+  rules:
+  - expr: node_network_receive_bytes_total
+    record: node_network_receive_bytes
+  - expr: node_network_receive_compressed_total
+    record: node_network_receive_compressed
+  - expr: node_network_receive_drop_total
+    record: node_network_receive_drop
+  - expr: node_network_receive_errs_total
+    record: node_network_receive_errs
+  - expr: node_network_receive_fifo_total
+    record: node_network_receive_fifo
+  - expr: node_network_receive_frame_total
+    record: node_network_receive_frame
+  - expr: node_network_receive_multicast_total
+    record: node_network_receive_multicast
+  - expr: node_network_receive_packets_total
+    record: node_network_receive_packets
+  - expr: node_network_transmit_bytes_total
+    record: node_network_transmit_bytes
+  - expr: node_network_transmit_compressed_total
+    record: node_network_transmit_compressed
+  - expr: node_network_transmit_drop_total
+    record: node_network_transmit_drop
+  - expr: node_network_transmit_errs_total
+    record: node_network_transmit_errs
+  - expr: node_network_transmit_fifo_total
+    record: node_network_transmit_fifo
+  - expr: node_network_transmit_frame_total
+    record: node_network_transmit_frame
+  - expr: node_network_transmit_multicast_total
+    record: node_network_transmit_multicast
+  - expr: node_network_transmit_packets_total
+    record: node_network_transmit_packets
+- name: node_exporter-16-nfs
+  rules:
+  - expr: node_nfs_connections_total
+    record: node_nfs_net_connections
+  - expr: node_nfs_packets_total
+    record: node_nfs_net_reads
+  - expr: label_replace(label_replace(node_nfs_requests_total, "proto", "$1", "version", "(.+)"), "method", "$1", "procedure", "(.+)")
+    record: node_nfs_procedures
+  - expr: node_nfs_rpc_authentication_refreshes_total
+    record: node_nfs_rpc_authentication_refreshes
+  - expr: node_nfs_rpcs_total
+    record: node_nfs_rpc_operations
+  - expr: node_nfs_rpc_retransmissions_total
+    record: node_nfs_rpc_retransmissions
+- name: node_exporter-16-textfile
+  rules:
+  - expr: node_textfile_mtime_seconds
+    record: node_textfile_mtime

--- a/base/prometheus/rules/node.rules
+++ b/base/prometheus/rules/node.rules
@@ -14,7 +14,7 @@ groups:
       description: Prometheus failed to scrape Node({{$labels.instance}}) for more than 2m
 
   - record: node_cpu_usage_rate
-    expr: (100 - (avg by(dedicated,instance)(irate(node_cpu{mode="idle"}[5m])) * 100))
+    expr: (100 - (avg by(dedicated,instance)(irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100))
   - alert: ManagementNodeCPUUsage
     expr: node_cpu_usage_rate{dedicated="management"} > 80
     for: 2m
@@ -128,7 +128,7 @@ groups:
       description: "{{$labels.instance}}: CPU usage is above 95% (current value is: {{$value}})"
 
   - alert: ManagementNodeLoadAverage5
-    expr: node_load5{dedicated="management"} / count without (cpu, mode) (node_cpu{mode="system"}) > 1
+    expr: node_load5{dedicated="management"} / count without (cpu, mode) (node_cpu_seconds_total{mode="system"}) > 1
     for: 2m
     labels:
       channel: default
@@ -139,7 +139,7 @@ groups:
       summary: "Node({{$labels.dedicated}}): High Load Average detected"
       description: "{{$labels.instance}}: Load Average is high (current value is: {{$value}})"
   - alert: LoggingNodeLoadAverage5
-    expr: node_load5{dedicated="logging"} / count without (cpu, mode) (node_cpu{mode="system"}) > 1
+    expr: node_load5{dedicated="logging"} / count without (cpu, mode) (node_cpu_seconds_total{mode="system"}) > 1
     for: 2m
     labels:
       channel: default
@@ -150,7 +150,7 @@ groups:
       summary: "Node({{$labels.dedicated}}): High Load Average detected"
       description: "{{$labels.instance}}: Load Average is high (current value is: {{$value}})"
   - alert: WorkerNodeLoadAverage5
-    expr: node_load5{dedicated=~"worker|ha-worker"} / count without (cpu, mode) (node_cpu{mode="system"}) > 1
+    expr: node_load5{dedicated=~"worker|ha-worker"} / count without (cpu, mode) (node_cpu_seconds_total{mode="system"}) > 1
     for: 2m
     labels:
       channel: default
@@ -161,7 +161,7 @@ groups:
       summary: "Node({{$labels.dedicated}}): High Load Average detected"
       description: "{{$labels.instance}}: Load Average is high (current value is: {{$value}})"
   - alert: EdgeNodeLoadAverage5
-    expr: node_load5{dedicated="edge"} / count without (cpu, mode) (node_cpu{mode="system"}) > 1
+    expr: node_load5{dedicated="edge"} / count without (cpu, mode) (node_cpu_seconds_total{mode="system"}) > 1
     for: 2m
     labels:
       channel: default
@@ -172,7 +172,7 @@ groups:
       summary: "Node({{$labels.dedicated}}): High Load Average detected"
       description: "{{$labels.instance}}: Load Average is high (current value is: {{$value}})"
   - alert: ZDBNodeLoadAverage5
-    expr: node_load5{dedicated="zdb"} / count without (cpu, mode) (node_cpu{mode="system"}) > 1
+    expr: node_load5{dedicated="zdb"} / count without (cpu, mode) (node_cpu_seconds_total{mode="system"}) > 1
     for: 2m
     labels:
       channel: default
@@ -183,14 +183,14 @@ groups:
       summary: "Node({{$labels.dedicated}}): High Load Average detected"
       description: "{{$labels.instance}}: Load Average is high (current value is: {{$value}})"
 
-  - record: node_memory_MemUsed
-    expr: node_memory_MemTotal - node_memory_MemFree - node_memory_Buffers - node_memory_Cached
+  - record: node_memory_MemUsed_bytes
+    expr: node_memory_MemTotal_bytes - node_memory_MemFree_bytes - node_memory_Buffers_bytes - node_memory_Cached_bytes
   - record: node_memory_MemUsed_percent
-    expr: node_memory_MemUsed / node_memory_MemTotal * 100
-  - record: node_memory_MemUnavailable
-    expr: node_memory_MemTotal - node_memory_MemAvailable
+    expr: node_memory_MemUsed_bytes / node_memory_MemTotal_bytes * 100
+  - record: node_memory_MemUnavailable_bytes
+    expr: node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes
   - record: node_memory_MemUnavailable_percent
-    expr: node_memory_MemUnavailable / node_memory_MemTotal * 100
+    expr: node_memory_MemUnavailable_bytes / node_memory_MemTotal_bytes * 100
   - alert: ManagementNodeMemoryUsage
     expr: node_memory_MemUsed_percent{dedicated="management"} > 80
     for: 2m
@@ -304,7 +304,7 @@ groups:
       description: "{{$labels.instance}}: Memory usage is above 95% (current value is: {{$value}})"
 
   - alert: NodeSwapUsage
-    expr: ((node_memory_SwapTotal - node_memory_SwapFree) / node_memory_SwapTotal) * 100 > 75
+    expr: ((node_memory_SwapTotal_bytes - node_memory_SwapFree_bytes) / node_memory_SwapTotal_bytes) * 100 > 75
     for: 2m
     labels:
       channel: default
@@ -315,10 +315,10 @@ groups:
       summary: "{{$labels.instance}}: Swap usage detected"
       description: "{{$labels.instance}}: Swap usage usage is above 75% (current value is: {{ $value }})"
 
-  - record: node_filesystem_used
-    expr: node_filesystem_size - node_filesystem_avail
+  - record: node_filesystem_used_bytes
+    expr: node_filesystem_size_bytes - node_filesystem_avail_bytes
   - record: node_filesystem_used_percent
-    expr: node_filesystem_used / node_filesystem_size * 100
+    expr: node_filesystem_used_bytes / node_filesystem_size_bytes * 100
   - alert: ManagementNodeLowRootDisk
     expr: node_filesystem_used_percent{dedicated="management",mountpoint="/"} > 80
     for: 30m


### PR DESCRIPTION
Closes #85 
* kube-state-metrics : v1.9.5
* node-exporter : v0.18.1
* blackbox-exporter : v0.16.0